### PR TITLE
Performance: cache PurgeCSS output

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "xo src tests",
     "format": "xo src tests --fix",
     "fmt": "yarn format",
+    "example:uncached": "rm -rf .remote-asset-cache && yarn example",
     "example": "rm -rf dist && src/cli.js 'fixtures/*.html' -o dist",
     "prepack": "yarn build",
     "release": "np"

--- a/src/cache.js
+++ b/src/cache.js
@@ -1,0 +1,57 @@
+const fs = require('fs').promises;
+const path = require('path');
+
+const cachePath = '.remote-asset-cache';
+const inMemory = new Map();
+
+/**
+ * @property {Function} set
+ * @property {Function} get
+ */
+const cache = {
+  /**
+   *
+   * @param {string} key
+   * @param {string} value
+   * @return {Promise<{ size: number, value: string }>}
+   */
+  async set(key, value) {
+    const cacheFilePath = path.join(cachePath, key);
+    await fs.writeFile(cacheFilePath, value, 'utf8');
+    const {size} = await fs.stat(cacheFilePath);
+    inMemory.set(key, {
+      size,
+      value
+    });
+    return {size, value};
+  },
+  /**
+   *
+   * @param {string} key
+   * @returns {Promise<{ size: number, value: string }>}
+   */
+  async get(key) {
+    let cachedVersion = inMemory.get(key);
+    if (!cachedVersion) {
+      // Not cached in memory
+      try {
+        const cacheFilePath = path.join(cachePath, key);
+        const {size} = await fs.stat(cacheFilePath);
+        const value = await fs.readFile(cacheFilePath, 'utf8');
+        cachedVersion = {
+          size,
+          value
+        };
+      } catch (_) {
+        // No cache for resource, init the directory, if it doesn't exist
+        fs.mkdir(cachePath).catch(() => {});
+      }
+    }
+
+    inMemory.set(key, cachedVersion);
+
+    return cachedVersion;
+  }
+};
+
+module.exports = cache;

--- a/src/inline-css.js
+++ b/src/inline-css.js
@@ -75,10 +75,7 @@ async function purgeStyles(html, styleSheetContents) {
   // Go through again to cache our output & populate `size`.
   purgedAssets = await Promise.all(
     purgedAssets.map(async ({url, asset}) => {
-      const {size} = await cache.set(
-        getStyleDigest(url),
-        asset.value
-      );
+      const {size} = await cache.set(getStyleDigest(url), asset.value);
       return {
         url,
         asset: {

--- a/src/inline-css.js
+++ b/src/inline-css.js
@@ -27,9 +27,15 @@ async function purgeStyles(html, styleSheetContents) {
   const cachedPurgedAssets = [];
   const assetsToPurge = [];
 
+  /**
+   * @param {string} url - URL of the stylesheet being digested
+   * @returns {string}
+   */
+  const getStyleDigest = (url) => `${htmlDigest}${digest(url)}`;
+
   // Get cached assets
   for await (const {url, asset} of styleSheetContents) {
-    const cached = await cache.get(`${htmlDigest}${digest(url)}`);
+    const cached = await cache.get(getStyleDigest(url));
     if (cached) {
       cachedPurgedAssets.push({
         url,
@@ -70,7 +76,7 @@ async function purgeStyles(html, styleSheetContents) {
   purgedAssets = await Promise.all(
     purgedAssets.map(async ({url, asset}) => {
       const {size} = await cache.set(
-        `${htmlDigest}${digest(url)}`,
+        getStyleDigest(url),
         asset.value
       );
       return {

--- a/src/inline-js.js
+++ b/src/inline-js.js
@@ -35,10 +35,7 @@ async function inlineJs(html, options) {
     scriptUrls.map(async (url) => {
       return {
         url,
-        asset: await loadRemoteAsset(url, {
-          cachePath: '.remote-asset-cache',
-          noCache: false
-        })
+        asset: await loadRemoteAsset(url)
       };
     })
   );

--- a/src/load-remote-asset.js
+++ b/src/load-remote-asset.js
@@ -1,81 +1,24 @@
-const fs = require('fs').promises;
 const fetch = require('node-fetch');
-
-const inMemory = new Map();
-
-/**
- * @property {Function} set
- * @property {Function} get
- */
-const cache = {
-  /**
-   *
-   * @param {string} key
-   * @param {string} value
-   * @return {Promise<{ size: number, value: string }>}
-   */
-  async set(key, value) {
-    await fs.writeFile(key, value, 'utf8');
-    const {size} = await fs.stat(key);
-    inMemory.set(key, {
-      size,
-      value
-    });
-    return {size, value};
-  },
-  /**
-   *
-   * @param {string} key
-   * @param {object} options
-   * @param {string} options.cachePath
-   * @returns {Promise<{ size: number, value: string }>}
-   */
-  async get(key, options) {
-    let cachedVersion = inMemory.get(key);
-    if (!cachedVersion) {
-      // Not cached in memory
-      try {
-        const {size} = await fs.stat(key);
-        const value = await fs.readFile(key, 'utf8');
-        cachedVersion = {
-          size,
-          value
-        };
-      } catch (_) {
-        // No cache for resource, init the directory, if it doesn't exist
-        fs.mkdir(options.cachePath).catch(() => {});
-      }
-    }
-
-    inMemory.set(key, cachedVersion);
-
-    return cachedVersion;
-  }
-};
+const cache = require('./cache');
+const {digest} = require('./utils');
 
 /**
  * Load & cache (to fs) remote stylesheets
  * @param {string} url - Stylesheet URL to load
- * @param {object} options
- * @param {boolean} options.noCache - Whether to use existing cache
- * @param {string} options.cachePath - Where to store the cache
  * @returns {Promise<{ size: number, value: string }>}
  */
-async function loadRemoteAsset(url, options) {
-  const {noCache, cachePath} = options;
-  const assetCachePath = `${cachePath}/${Buffer.from(url).toString('base64')}`;
-  // Cache enabled by default
-  if (!noCache) {
-    const cachedVersion = await cache.get(assetCachePath, options);
-    if (cachedVersion) {
-      return cachedVersion;
-    }
+async function loadRemoteAsset(url) {
+  const assetKey = digest(url);
+
+  const cachedVersion = await cache.get(assetKey);
+  if (cachedVersion) {
+    return cachedVersion;
   }
 
   // @ts-ignore
   const value = await fetch(url).then((response) => response.text());
   // Cache loaded resource & compute size
-  const {size} = await cache.set(assetCachePath, value);
+  const {size} = await cache.set(assetKey, value);
 
   return {value, size};
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,7 @@
+const fs = require('fs').promises;
+const path = require('path');
+const crypto = require('crypto');
+
 /**
  *
  * @param {string} tag
@@ -12,8 +16,14 @@ function matchRemoteResource(tag, resourceLocationRegex) {
   return location.startsWith('http') ? location : null;
 }
 
-const fs = require('fs').promises;
-const path = require('path');
+/**
+ *
+ * @param {string} string - string to digest
+ * @returns {string}
+ */
+function digest(string) {
+  return crypto.createHash('sha256').update(string).digest('hex');
+}
 
 /**
  * @param {string} p - Path to check
@@ -37,5 +47,6 @@ async function ensureWriteablePath(filePath) {
 
 module.exports = {
   matchRemoteResource,
+  digest,
   ensureWriteablePath
 };

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,4 +1,11 @@
+declare const cache: {
+    set: (...params: any[]) => any;
+    get: (...params: any[]) => any;
+};
+
 declare function matchRemoteHref(tag: string): string | null;
+
+declare function purgeStyles(html: string, styleSheetContents: { url: string; asset: { value: string; size: number; }; }[]): Promise<{ url: string; asset: { value: string; size: number; }; }[]>;
 
 /**
  * Inline & purge CSS rules from CDN/remote includes into HTML
@@ -17,21 +24,11 @@ declare function inlineJs(html: string, options: {
     maxSize: number;
 }): Promise<string>;
 
-declare const cache: {
-    set: (...params: any[]) => any;
-    get: (...params: any[]) => any;
-};
-
 /**
  * Load & cache (to fs) remote stylesheets
  * @param url - Stylesheet URL to load
- * @param options.noCache - Whether to use existing cache
- * @param options.cachePath - Where to store the cache
  */
-declare function loadRemoteAsset(url: string, options: {
-    noCache: boolean;
-    cachePath: string;
-}): Promise<{ size: number; value: string; }>;
+declare function loadRemoteAsset(url: string): Promise<{ size: number; value: string; }>;
 
 /**
  * Inline Remote Assets
@@ -47,6 +44,11 @@ declare module "inline-remote-assets/main" {
 }
 
 declare function matchRemoteResource(tag: string, resourceLocationRegex: RegExp): string | null;
+
+/**
+ * @param string - string to digest
+ */
+declare function digest(string: string): string;
 
 /**
  * @param p - Path to check


### PR DESCRIPTION
- Extract cache to its own file
- Create new `digest` util (uses Node.js crypto SHA256 -> hex hash digest)
- add caching for PurgeCSS output
- adds `size` measurement for Purged CSS (opens the path to maxSize support for CSS)

### Results

Uncached:

```sh
yarn example:uncached
yarn run v1.21.1
$ rm -rf .remote-asset-cache && yarn example
$ rm -rf dist && src/cli.js 'fixtures/*.html' -o dist
fixtures/sample.html -> dist/sample.html: 1831.639ms
✨  Done in 3.12s.
```

Cache

```sh
yarn example
yarn run v1.21.1
$ rm -rf dist && src/cli.js 'fixtures/*.html' -o dist
fixtures/sample.html -> dist/sample.html: 16.493ms
✨  Done in 0.63s.
```